### PR TITLE
Consolidated model and feature detection & added additional detection for K2 Plus

### DIFF
--- a/custom_components/ha_creality_ws/switch.py
+++ b/custom_components/ha_creality_ws/switch.py
@@ -4,35 +4,23 @@ from homeassistant.components.switch import SwitchEntity
 
 from .entity import KEntity
 from .const import DOMAIN
-
+from .utils import ModelDetection
 # Only keep switches that make sense as binary (e.g., light).
 MAP = {
     "light": ("Light", "lightSw"),
     # Fan switches removed; use % numbers instead.
 }
 
-
 async def async_setup_entry(hass, entry, async_add_entities):
     coord = hass.data[DOMAIN][entry.entry_id]
     
     # Model detection logic
-    model = (coord.data or {}).get("model") or ""
-    model_l = str(model).lower()
-    
-    is_k1_family = "k1" in model_l
-    is_k1_se = is_k1_family and "se" in model_l
-    is_k1_max = is_k1_family and "max" in model_l
-    is_k2_family = "k2" in model_l
-    is_ender_v3_family = "ender" in model_l and "v3" in model_l
-    is_creality_hi = "hi" in model_l
-    
-    # Models without light: K1 SE, Ender 3 V3 family
-    has_light = not (is_k1_se or is_ender_v3_family)
+    printermodel = ModelDetection(coord.data)
     
     ents = []
     for key, (name, field) in MAP.items():
         # Skip light switch for models without light
-        if key == "light" and not has_light:
+        if key == "light" and not printermodel.has_light:
             continue
         ents.append(KSimpleSwitch(coord, name, field, key))
     

--- a/custom_components/ha_creality_ws/utils.py
+++ b/custom_components/ha_creality_ws/utils.py
@@ -102,3 +102,24 @@ def extract_host_from_zeroconf(info: Any) -> Optional[str]:
     except Exception:
         pass
     return None
+
+class ModelDetection():
+    def __init__(self, coord_data):
+        
+        self.model = (coord_data or {}).get("model") or ""
+        self.model_l = str(self.model).lower()
+        self.modelversion = (coord_data or {}).get("'modelVersion': ") or "" #can do something here with checking against a list of known model/mainboard versions. This may be more reliable that checking model name, but I don't have info on other boards.
+        
+        self.is_k1_family = "k1" in self.model_l
+        self.is_k1_se = self.is_k1_family and "se" in self.model_l
+        self.is_k1_max = self.is_k1_family and "max" in self.model_l
+        self.is_k2_family = "k2" in self.model_l or "f008" in self.model_l
+        self.is_k2_base = self.is_k2_family and not ("pro" in self.model_l or "plus" in self.model_l)
+        self.is_k2_pro = self.is_k2_family and "pro" in self.model_l
+        self.is_k2_plus = (self.is_k2_family and "plus" in self.model_l) or "f008" in self.model_l
+        self.is_ender_v3_family = "ender" in self.model_l and "v3" in self.model_l
+        self.is_creality_hi = "hi" in self.model_l
+    # Models with box temperature control: Only K2 Pro and K2 Plus
+        self.has_box_control = self.is_k2_pro or self.is_k2_plus
+        self.has_box_sensor = (self.is_k1_family and not self.is_k1_se) or self.is_k1_max or self.is_k2_family or self.is_creality_hi
+        self.has_light = not (self.is_k1_se or self.is_ender_v3_family)


### PR DESCRIPTION
1) I've moved all the model detection to a single class called `ModelDetection` in the utils.py file. This way any changes to model detection only needs to be done in one place. All the other places now reference this class e.g. `printermodel.is_k1_family`

2) The `model` from websocket doesn't seem to always list the full model names e.g. "K2 Plus". My printer shows "F008" as the model. I've added "f008" to the K2 Plus and K2 Family detection.

Also see #8 for some additional discussion.