### PR TITLE
fix: restore #format=creality on go2rtc source for K2 WebRTC cameras (0.9.4)

### DIFF
--- a/.release_notes/RELEASE_NOTES.md
+++ b/.release_notes/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.4] - 2026-05-21
+> [List of issues (0.9.4)](https://github.com/3dg1luk43/ha_creality_ws/issues?q=is%3Aissue+milestone%3Av0.9.4)
+
+### Fixed
+- **K2 WebRTC Camera Regression** (#87, #88):
+  - Restored the `#format=creality` go2rtc source fragment for K2 family WebRTC cameras, which selects go2rtc's built-in Creality JSON-wrapped SDP client.
+  - In 0.9.3 the fragment was dropped on the assumption it was no longer needed, but the K2/K2 Pro/K2 Combo signaling endpoint at `:8000/call/webrtc_local` does not speak standard WHEP — it replies with `{}` to raw SDP offers, which made go2rtc fail with `sdp: syntax error at pos 1: "}"` and caused the camera entity to become unavailable.
+  - 0.9.3 users seeing "Failed to start WebRTC stream: go2rtc error" or a permanently unavailable camera entity should be fixed by upgrading to 0.9.4 without any config changes.
+
+
 ## [0.9.3] - 2026-05-20
 > [List of issues (0.9.3)](https://github.com/3dg1luk43/ha_creality_ws/issues?q=is%3Aissue+milestone%3Av0.9.3)
 

--- a/custom_components/ha_creality_ws/camera.py
+++ b/custom_components/ha_creality_ws/camera.py
@@ -645,9 +645,12 @@ class CrealityWebRTCCamera(_BaseCamera):
             )
             return
         
-        # Configure stream source
-        # Note: go2rtc 1.9.14+ compatibility - use standard webrtc source
-        go2rtc_src = f"webrtc:{self._upstream_signaling_url}"
+        # Configure stream source.
+        # The K2 family signaling endpoint speaks Creality's JSON-wrapped SDP
+        # protocol, not standard WHEP. The `#format=creality` fragment selects
+        # go2rtc's built-in Creality client; dropping it makes go2rtc send raw
+        # WHEP, which the printer replies to with `{}` and breaks the stream.
+        go2rtc_src = f"webrtc:{self._upstream_signaling_url}#format=creality"
         
         try:
             # Check if stream already exists

--- a/custom_components/ha_creality_ws/manifest.json
+++ b/custom_components/ha_creality_ws/manifest.json
@@ -13,7 +13,7 @@
     "websockets>=10.4",
     "go2rtc-client>=0.1.0"
   ],
-  "version": "0.9.2",
+  "version": "0.9.4",
   "zeroconf": [
     { "type": "_http._tcp.local.", "name": "*creality*" },
     { "type": "_workstation._tcp.local.", "name": "*creality*" },

--- a/tools/tests/test_camera_stream_config.py
+++ b/tools/tests/test_camera_stream_config.py
@@ -39,9 +39,10 @@ else:
 
 from custom_components.ha_creality_ws.camera import CrealityWebRTCCamera
 
-def test_ensure_stream_configured_modern():
+def test_ensure_stream_configured_uses_creality_format():
     import asyncio
-    # Test that it adds stream WITHOUT format=creality
+    # K2 signaling uses Creality's JSON-wrapped SDP, not raw WHEP — the
+    # `#format=creality` fragment must remain on the go2rtc source. See #87/#88.
 
     mock_go2rtc_client = MagicMock()
     mock_go2rtc_client.streams = MagicMock()
@@ -71,5 +72,4 @@ def test_ensure_stream_configured_modern():
     call_args = mock_go2rtc_client.streams.add.call_args
     assert "sources" in call_args.kwargs
     source = call_args.kwargs["sources"]
-    assert "#format=creality" not in source
-    assert source == "webrtc:http://1.2.3.4:8000/call/webrtc_local"
+    assert source == "webrtc:http://1.2.3.4:8000/call/webrtc_local#format=creality"


### PR DESCRIPTION
## Summary
- Fixes #87 and #88 — the K2 / K2 Pro / K2 Combo camera entity becomes unavailable on 0.9.3 with `go2rtc error: 500` / `sdp: syntax error at pos 1: "}"` in the logs.
- The K2 signaling endpoint at `:8000/call/webrtc_local` speaks Creality's JSON-wrapped SDP protocol, not standard WHEP. The `#format=creality` fragment selects go2rtc's built-in Creality client, which is what 0.9.2 used. 0.9.3 dropped it on the assumption it was no longer needed for newer go2rtc, but that's what broke compatibility — the printer replies `{}` to raw WHEP offers and go2rtc can't parse it as SDP, so the stream is invalidated and the recovery loop keeps recreating the same broken source.
- One-line fix at [camera.py:650](custom_components/ha_creality_ws/camera.py#L650), test that was pinning the broken behavior updated to assert the correct source, manifest bumped to 0.9.4, release notes added.

## Test plan
- [x] `pytest tools/tests/` — all 27 tests pass (was 0 broken, now 1 corrected)
- [ ] Smoke test on K2 Pro (F012) — confirm camera entity goes available and stream loads
- [ ] Smoke test on K2 Combo (F021) — same
- [ ] Confirm no regression on K1 family (MJPEG path is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed K2 WebRTC camera streaming regression introduced in v0.9.3 by restoring the required Creality-specific streaming format for proper operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3dg1luk43/ha_creality_ws/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->