### PR TITLE
fix: resolve CFS sensors availability issue after upgrade to 0.9.6

### DIFF
--- a/.release_notes/RELEASE_NOTES.md
+++ b/.release_notes/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.6.1] - 2026-06-11
+> [List of issues (0.9.6.1)](https://github.com/3dg1luk43/ha_creality_ws/issues?q=is%3Aissue+milestone%3Av0.9.6.1)
+
+### Fixed
+- **CFS sensors stuck unavailable after upgrading to 0.9.6** (#99, regression):
+  - All CFS sensors (box temp/humidity, every slot's filament/color/percent, the external slot) and the **Active Filament Slot** sensor stayed `unavailable` after a few minutes and never recovered, even across Home Assistant and printer restarts. Rolling back to 0.9.4 worked around it.
+  - `boxsInfo` (the CFS payload) is only sent by the printer in response to an explicit poll, never in the regular telemetry stream. The 0.9.6 rework of the periodic-GET loop started its poll timers at the current time instead of zero, which pushed the **first** CFS poll a full 5 minutes (`GET_BOXS_INFO_SEC`) past connect. Because every reconnect restarts that timer, any printer that dropped and reconnected more often than every 5 minutes never got polled at all — so the CFS entities were never discovered and sat unavailable.
+  - The first poll of each periodic GET (printer params, print objects, and CFS box info) now fires immediately once the connection is ready, restoring the pre-0.9.6 behavior. The 5-minute steady-state cadence for CFS is unchanged, and the 0.9.6 "availability requires real data" gate still applies.
+
+
 ## [0.9.6] - 2026-06-10
 > [List of issues (0.9.6)](https://github.com/3dg1luk43/ha_creality_ws/issues?q=is%3Aissue+milestone%3Av0.9.6)
 

--- a/custom_components/ha_creality_ws/manifest.json
+++ b/custom_components/ha_creality_ws/manifest.json
@@ -13,7 +13,7 @@
     "websockets>=10.4",
     "go2rtc-client>=0.1.0"
   ],
-  "version": "0.9.6",
+  "version": "0.9.6.1",
   "zeroconf": [
     { "type": "_http._tcp.local.", "name": "*creality*" },
     { "type": "_workstation._tcp.local.", "name": "*creality*" },

--- a/custom_components/ha_creality_ws/ws_client.py
+++ b/custom_components/ha_creality_ws/ws_client.py
@@ -432,9 +432,16 @@ class KClient:
         try:
             await asyncio.sleep(2.0)
             now = time.monotonic()
-            t_para = now
-            t_objs = now
-            t_cfs = now
+            # Back-date each timer by its own interval so the first poll of each
+            # fires on the first ready iteration instead of a full interval after
+            # connect. Critical for CFS: boxsInfo is only sent on request (never
+            # in the regular stream), so a `now`-initialised t_cfs left CFS
+            # sensors unavailable for the full 5-minute interval after every
+            # (re)connect (issue #99). The _ws_ready gate below still prevents
+            # sending before the connection has proven it's talking.
+            t_para = now - GET_REQPRINTERPARA_SEC
+            t_objs = now - GET_PRINT_OBJECTS_SEC
+            t_cfs = now - GET_BOXS_INFO_SEC
             # Staggered loop to avoid bursts
             while True:
                 now = time.monotonic()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a regression where CFS sensors (box/slot sensors and Active Filament Slot sensor) remained unavailable after upgrading to version 0.9.6. These sensors now initialize and poll immediately upon connection establishment, while maintaining the standard 5-minute polling interval thereafter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->