### PR TITLE
change max print tuning to 200% to make it usable

### DIFF
--- a/custom_components/ha_creality_ws/number.py
+++ b/custom_components/ha_creality_ws/number.py
@@ -58,7 +58,7 @@ class PrintTuningPercent(KEntity, NumberEntity):
     _attr_native_unit_of_measurement = UNIT_PERCENT
     _attr_mode = NumberMode.SLIDER
     _attr_native_min_value = 1.0
-    _attr_native_max_value = 1000.0
+    _attr_native_max_value = 200.0
     _attr_native_step = 1.0
 
     def __init__(self, coordinator) -> None:


### PR DESCRIPTION
The max value of print tuning is 1000%, but the fluidd only supports up to 200, and the app / config only 125% on the k2 pro. to make the slider usable, i want to suggest changing the max value to 200. i'd also prefer a step size of 5 or 25, but that can very well be to personal to push to all users :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the maximum allowed value for the print tuning percentage control, so the slider now stops at a lower, more realistic upper limit.
  * Prevents overly large values from being entered or applied in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->