### PR TITLE
fix: card display fixes, power-off confirmation, and currentObject crash (#101, #103, #106)

### DIFF
--- a/custom_components/ha_creality_ws/sensor.py
+++ b/custom_components/ha_creality_ws/sensor.py
@@ -491,15 +491,17 @@ class CurrentObjectSensor(KEntity, SensorEntity):
         
         d = self.coordinator.data or {}
         v = d.get("current_object") or d.get("currentObject")
-        
-        # If no current object and printer is not printing, show "not printing"
-        if not v or v.strip() == "":
+
+        # If no current object and printer is not printing, show "not printing".
+        # Firmware may send this as a non-string (e.g. an int object index), so
+        # only run the whitespace check on actual strings to avoid AttributeError.
+        if not v or (isinstance(v, str) and not v.strip()):
             # Check if printer is actually printing
             fname = d.get("printFileName") or ""
             if not fname:
                 return "not printing"
             return None
-        
+
         return str(v)
 
     @property

--- a/custom_components/ha_creality_ws/www/i18n/en.json
+++ b/custom_components/ha_creality_ws/www/i18n/en.json
@@ -2,6 +2,8 @@
   "printer_card": {
     "status_unknown": "Unknown",
     "confirm_stop": "Are you sure you want to stop the print?",
+    "confirm_power_off": "Are you sure you want to power off the printer?",
+    "confirm_power_off_printing": "A print is in progress. Are you sure you want to power off the printer?",
     "chip_pause": "Pause",
     "chip_resume": "Resume",
     "chip_stop": "Stop",

--- a/custom_components/ha_creality_ws/www/i18n/es.json
+++ b/custom_components/ha_creality_ws/www/i18n/es.json
@@ -2,6 +2,8 @@
   "printer_card": {
     "status_unknown": "Desconocido",
     "confirm_stop": "¿Seguro que deseas detener la impresión?",
+    "confirm_power_off": "¿Seguro que deseas apagar la impresora?",
+    "confirm_power_off_printing": "Hay una impresión en curso. ¿Seguro que deseas apagar la impresora?",
     "chip_pause": "Pausar",
     "chip_resume": "Reanudar",
     "chip_stop": "Detener",

--- a/custom_components/ha_creality_ws/www/k_printer_card.js
+++ b/custom_components/ha_creality_ws/www/k_printer_card.js
@@ -123,7 +123,9 @@ function generateCardId(config) {
 }
 
 function fmtTimeLeft(seconds) {
-  const s = Number(seconds) || 0;
+  // Floor to whole seconds so a fractional value (some firmwares report a float)
+  // renders as e.g. 2:25 instead of 2:25.6789 and doesn't reflow the row every poll.
+  const s = Math.floor(Number(seconds) || 0);
   const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
   if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
   if (m > 0) return `${m}:${String(sec).padStart(2, "0")}`;
@@ -465,6 +467,15 @@ class KPrinterCard extends HTMLElement {
 
       if (id === "power") {
         const eid = this._resolveEntityId(this._cfg.power, ["switch"]);
+        // Confirm only when the press would turn the printer OFF (not when
+        // turning it on), with a stronger warning while a print is in progress
+        // so an accidental tap can't kill a running job.
+        if (this._hass?.states?.[eid]?.state === "on") {
+          const st = normStr(this._hass?.states?.[this._cfg.status]?.state);
+          const printing = ["printing", "resuming", "pausing", "paused"].includes(st);
+          const msg = printing ? this._t("confirm_power_off_printing") : this._t("confirm_power_off");
+          if (!confirm(msg)) return;
+        }
         this._toggleEntity(eid);
       } else if (id === "light") {
         const eid = this._resolveEntityId(this._cfg.light, ["light", "switch"]);
@@ -823,16 +834,18 @@ class KPrinterCard extends HTMLElement {
     this._root.getElementById("bed").textContent = bedStr;
     this._root.getElementById("box").textContent = boxStr;
     this._root.getElementById("time").textContent = fmtTimeLeft(timeLeft);
-    this._root.getElementById("layers").textContent = `${layer || "?"}/${totalLayers || "?"}`;
+    this._root.getElementById("layers").textContent = `${layer || "—"}/${totalLayers || "—"}`;
 
-    // Toggle Chamber Temp visibility
+    // Toggle Chamber Temp visibility.
+    // Hide when explicitly hidden, when no chamber entity is configured, or when
+    // the configured entity does not exist in HA (printers without a chamber,
+    // e.g. Ender 3 V3 KE) so we don't render a stray thermometer icon that
+    // offsets the adjacent telemetry. A configured-but-unavailable entity stays
+    // visible and shows "—", matching the nozzle/bed pills.
     const boxPill = this._root.getElementById("box-pill");
     if (boxPill) {
-      if (this._cfg.hide_box_temp) {
-        boxPill.style.display = "none";
-      } else {
-        boxPill.style.display = "";
-      }
+      const boxConfigured = Boolean(this._cfg.box) && Boolean(this._hass?.states?.[this._cfg.box]);
+      boxPill.style.display = (this._cfg.hide_box_temp || !boxConfigured) ? "none" : "";
     }
     this._scheduleTelemetrySizeUpdate();
   }
@@ -841,6 +854,8 @@ const CARD_TRANSLATIONS = {
   en: {
     status_unknown: "Unknown",
     confirm_stop: "Are you sure you want to stop the print?",
+    confirm_power_off: "Are you sure you want to power off the printer?",
+    confirm_power_off_printing: "A print is in progress. Are you sure you want to power off the printer?",
     chip_pause: "Pause",
     chip_resume: "Resume",
     chip_stop: "Stop",


### PR DESCRIPTION
Fixes three open issues.

## #106 — `CurrentObjectSensor` crash (bug)
`native_value` called `.strip()` on `currentObject`, which some firmwares (e.g. K1) report as a non-string int, raising `AttributeError: 'int' object has no attribute 'strip'` roughly every 5 seconds. The whitespace check is now guarded with `isinstance(v, str)`, so only strings are stripped. All other outputs are unchanged (falsy / whitespace / missing → "not printing"; otherwise `str(v)`).

Fixes #106

## #103 — Time decimals & blank chamber icon on card (bug)
- `fmtTimeLeft` now floors to whole seconds, so a fractional `time_left` renders as `2:25` instead of `2:25.6789`. This also stops the telemetry row from reflowing on every poll (the "jarring offset").
- The chamber/box pill auto-hides when no chamber entity is configured (or the configured entity is absent from HA), so chamber-less printers such as the Ender 3 V3 KE no longer render a stray thermometer icon. A configured-but-unavailable entity stays visible showing `—`, matching the nozzle/bed pills.

Fixes #103

## #101 — Card enhancements (feature request)
- Layer readout falls back to `—/—` (consistent with the temperature pills) instead of `?/?` when the printer is off or idle.
- The power button now prompts for confirmation — but only when the press would turn the printer **off** (never when turning it on) — with a stronger warning while a print is in progress, so an accidental tap can't kill a running job. New `confirm_power_off` / `confirm_power_off_printing` strings added to the card fallback dictionary and to `www/i18n/en.json` + `es.json`.

Fixes #101

## Testing
- Card changes verified in a running Home Assistant instance (time formatting, `—/—` layer readout, hidden chamber pill, and the power-off confirmation prompt).
- `sensor.py`: `py_compile` + `ruff` clean; crash path verified with int / string / whitespace / missing inputs.
- `k_printer_card.js`: `node --check` clean; both i18n JSON files validated.
